### PR TITLE
백엔드 추가 기능 구현

### DIFF
--- a/src/main/java/spoticks/ticket_reservation/domain/game/controller/GameController.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/controller/GameController.java
@@ -65,9 +65,16 @@ public class GameController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping({"/admin/games", "/games/sports"})
+    @GetMapping("/admin/games")
     public ResponseEntity getGamesBySport(@RequestParam(defaultValue = "") String sport, @RequestParam(defaultValue = "1") int page) {
-        Page<Game> gamePage = gameFacadeService.getGamesBySport(page, sport);
+        Page<Game> gamePage = gameFacadeService.getAllGamesBySport(page, sport);
+        List<GameDto.Res> gameList = GameDto.toResList(gamePage.getContent());
+        return new ResponseEntity<>(new MultiResponseDto<>(gameList, gamePage), HttpStatus.OK);
+    }
+
+    @GetMapping("/games/sports")
+    public ResponseEntity getUpcomingMatchesBySport(@RequestParam String sport, @RequestParam(defaultValue = "1") int page) {
+        Page<Game> gamePage = gameFacadeService.getUpcomingGamesBySport(page, sport);
         List<GameDto.Res> gameList = GameDto.toResList(gamePage.getContent());
         return new ResponseEntity<>(new MultiResponseDto<>(gameList, gamePage), HttpStatus.OK);
     }

--- a/src/main/java/spoticks/ticket_reservation/domain/game/controller/GameController.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/controller/GameController.java
@@ -44,9 +44,18 @@ public class GameController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
+    @GetMapping("/games/sports")
+    public ResponseEntity getUpcomingMatchesBySport(@RequestParam String sport, @RequestParam(defaultValue = "1") int page) {
+        Page<Game> gamePage = gameFacadeService.getUpcomingGamesBySport(page, sport);
+        List<GameDto.Res> gameList = GameDto.toResList(gamePage.getContent());
+        return new ResponseEntity<>(new MultiResponseDto<>(gameList, gamePage), HttpStatus.OK);
+    }
+
     @GetMapping("/teams/{teamId}/games")
-    public ResponseEntity getGamesByTeam(@PathVariable long teamId, @RequestParam(defaultValue = "1") int page) {
-        Page<Game> gamePage = gameFacadeService.getGamesByTeam(page, teamId);
+    public ResponseEntity getUpcomingMatchesByTeam(@PathVariable long teamId,
+                                                   @RequestParam(defaultValue = "1") int page,
+                                                   @RequestParam(defaultValue = "false") boolean onlyHomeGames) {
+        Page<Game> gamePage = gameFacadeService.getUpcomingGamesByTeam(page, teamId, onlyHomeGames);
         List<GameDto.Res> gameList = GameDto.toResList(gamePage.getContent());
         return new ResponseEntity<>(new MultiResponseDto<>(gameList, gamePage), HttpStatus.OK);
     }
@@ -68,13 +77,6 @@ public class GameController {
     @GetMapping("/admin/games")
     public ResponseEntity getGamesBySport(@RequestParam(defaultValue = "") String sport, @RequestParam(defaultValue = "1") int page) {
         Page<Game> gamePage = gameFacadeService.getAllGamesBySport(page, sport);
-        List<GameDto.Res> gameList = GameDto.toResList(gamePage.getContent());
-        return new ResponseEntity<>(new MultiResponseDto<>(gameList, gamePage), HttpStatus.OK);
-    }
-
-    @GetMapping("/games/sports")
-    public ResponseEntity getUpcomingMatchesBySport(@RequestParam String sport, @RequestParam(defaultValue = "1") int page) {
-        Page<Game> gamePage = gameFacadeService.getUpcomingGamesBySport(page, sport);
         List<GameDto.Res> gameList = GameDto.toResList(gamePage.getContent());
         return new ResponseEntity<>(new MultiResponseDto<>(gameList, gamePage), HttpStatus.OK);
     }

--- a/src/main/java/spoticks/ticket_reservation/domain/game/dto/GameDto.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/dto/GameDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import spoticks.ticket_reservation.domain.game.entity.Game;
+import spoticks.ticket_reservation.domain.game.entity.LeagueSeason;
 import spoticks.ticket_reservation.domain.seat.entity.Seat;
 import spoticks.ticket_reservation.domain.sport.entity.Sport;
 import spoticks.ticket_reservation.domain.stadium.entity.Stadium;
@@ -54,6 +55,7 @@ public class GameDto {
 
         private Stadium stadium;
         private Sport sport;
+        private LeagueSeason season;
         private Team homeTeam;
         private Team awayTeam;
         private ZonedDateTime gameStartTime;

--- a/src/main/java/spoticks/ticket_reservation/domain/game/entity/Game.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/entity/Game.java
@@ -34,6 +34,10 @@ public class Game extends BaseTimeEntity {
     @JoinColumn(name = "sport_id", nullable = false)
     private Sport sport;
 
+    @Column
+    @Enumerated(EnumType.STRING)
+    private LeagueSeason season;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "home_team_id", nullable = false)
     private Team homeTeam;
@@ -56,9 +60,10 @@ public class Game extends BaseTimeEntity {
     private List<Seat> seats = new ArrayList<>();
 
     @Builder
-    public Game(Stadium stadium, Sport sport, Team homeTeam, Team awayTeam, ZonedDateTime gameStartTime) {
+    public Game(Stadium stadium, Sport sport, LeagueSeason season, Team homeTeam, Team awayTeam, ZonedDateTime gameStartTime) {
         this.stadium = stadium;
         this.sport = sport;
+        this.season = season;
         this.homeTeam = homeTeam;
         this.awayTeam = awayTeam;
         this.gameStartTime = gameStartTime;

--- a/src/main/java/spoticks/ticket_reservation/domain/game/entity/LeagueSeason.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/entity/LeagueSeason.java
@@ -1,0 +1,13 @@
+package spoticks.ticket_reservation.domain.game.entity;
+
+public enum LeagueSeason {
+
+    K1_2024,
+    KBO_2024,
+    KBL_2024_25,
+    V_2024_25,
+    K_2025,
+    KBO_2025,
+    UNTITLED
+
+}

--- a/src/main/java/spoticks/ticket_reservation/domain/game/exception/GameNotFoundException.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/exception/GameNotFoundException.java
@@ -6,7 +6,7 @@ import spoticks.ticket_reservation.global.error.exception.EntityNotFoundExceptio
 public class GameNotFoundException extends EntityNotFoundException {
 
     public GameNotFoundException() {
-        super("Game not found", ErrorCode.GAME_NOT_FOUND);
+        super(ErrorCode.GAME_NOT_FOUND);
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/game/repository/GameRepository.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/repository/GameRepository.java
@@ -19,6 +19,8 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 
     Page<Game> findBySport(Sport sport, Pageable pageable);
 
+    Page<Game> findBySportAndTimeOffSaleAfter(Sport sport, ZonedDateTime timeOffSaleAfter, Pageable pageable);
+
     Page<Game> findByHomeTeamOrAwayTeamOrderByGameStartTime(Team homeTeam, Team awayTeam, Pageable pageable);
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/game/repository/GameRepository.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/repository/GameRepository.java
@@ -2,6 +2,7 @@ package spoticks.ticket_reservation.domain.game.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,7 +18,7 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 
     Optional<Game> findFirstByTimeOnSaleBeforeAndTimeOffSaleAfter(ZonedDateTime timeOnSaleBefore, ZonedDateTime timeOffSaleAfter);
 
-    List<Game> findByTimeOffSaleBetween(ZonedDateTime start, ZonedDateTime end);
+    List<Game> findByTimeOffSaleBetween(ZonedDateTime start, ZonedDateTime end, Sort sort);
 
     Page<Game> findBySport(Sport sport, Pageable pageable);
 

--- a/src/main/java/spoticks/ticket_reservation/domain/game/repository/GameRepository.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/repository/GameRepository.java
@@ -3,6 +3,8 @@ package spoticks.ticket_reservation.domain.game.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import spoticks.ticket_reservation.domain.game.entity.Game;
 import spoticks.ticket_reservation.domain.sport.entity.Sport;
 import spoticks.ticket_reservation.domain.team.entity.Team;
@@ -21,6 +23,13 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 
     Page<Game> findBySportAndTimeOffSaleAfter(Sport sport, ZonedDateTime timeOffSaleAfter, Pageable pageable);
 
-    Page<Game> findByHomeTeamOrAwayTeamOrderByGameStartTime(Team homeTeam, Team awayTeam, Pageable pageable);
+    Page<Game> findByHomeTeamAndTimeOffSaleAfter(Team homeTeam, ZonedDateTime timeOffSaleAfter, Pageable pageable);
+
+    @Query("SELECT g FROM Game g " +
+            "WHERE g.timeOffSale > :timeOffSaleAfter " +
+            "AND (g.homeTeam = :homeTeam OR g.awayTeam = :awayTeam)")
+    Page<Game> findByHomeTeamOrAwayTeamAndTimeOffSaleAfter(@Param("timeOffSaleAfter") ZonedDateTime timeOffSaleAfter,
+                                                           @Param("homeTeam") Team homeTeam,
+                                                           @Param("awayTeam") Team awayTeam, Pageable pageable);
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/game/service/GameFacadeService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/service/GameFacadeService.java
@@ -115,9 +115,9 @@ public class GameFacadeService {
         return gameService.findGamesBySport(page, sport, false);
     }
 
-    public Page<Game> getGamesByTeam(int page, long teamId) {
+    public Page<Game> getUpcomingGamesByTeam(int page, long teamId, boolean onlyHomeGames) {
         Team team = teamService.findById(teamId);
-        return gameService.findGamesByTeam(page, team);
+        return gameService.findGamesByTeam(page, team, onlyHomeGames);
     }
 
     public void deleteGame(long gameId) {

--- a/src/main/java/spoticks/ticket_reservation/domain/game/service/GameFacadeService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/service/GameFacadeService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spoticks.ticket_reservation.domain.game.dto.GameDto;
 import spoticks.ticket_reservation.domain.game.entity.Game;
+import spoticks.ticket_reservation.domain.game.entity.LeagueSeason;
 import spoticks.ticket_reservation.domain.game.exception.GameTimeOutOfBoundException;
 import spoticks.ticket_reservation.domain.game.exception.HomeAndAwaySameException;
 import spoticks.ticket_reservation.domain.seat.service.SeatService;
@@ -40,6 +41,7 @@ public class GameFacadeService {
         Game newGame = Game.builder()
                 .stadium(stadium)
                 .sport(sportService.findBySportName(dto.getSport()))
+                .season(getLeagueSeason(dto.getSport()))
                 .homeTeam(teamService.findById(dto.getHomeTeamId()))
                 .awayTeam(teamService.findById(dto.getAwayTeamId()))
                 .gameStartTime(dto.getGameStartTime())
@@ -90,6 +92,7 @@ public class GameFacadeService {
         GameDto.ModifyInfoRes res = GameDto.ModifyInfoRes.builder()
                 .stadium(stadiumService.findByStadiumName(dto.getStadiumName()))
                 .sport(sportService.findBySportName(dto.getSport()))
+                .season(getLeagueSeason(dto.getSport()))
                 .homeTeam(teamService.findById(dto.getHomeTeamId()))
                 .awayTeam(teamService.findById(dto.getAwayTeamId()))
                 .gameStartTime(dto.getGameStartTime())
@@ -98,13 +101,18 @@ public class GameFacadeService {
         gameService.saveGame(game);
     }
 
-    public Page<Game> getGamesBySport(int page, String sportName) {
+    public Page<Game> getAllGamesBySport(int page, String sportName) {
         if (sportName.isEmpty()) {
             return gameService.getAllGames(page);
         } else {
             Sport sport = sportService.findBySportName(sportName);
-            return gameService.findGamesBySport(page, sport);
+            return gameService.findGamesBySport(page, sport, true);
         }
+    }
+
+    public Page<Game> getUpcomingGamesBySport(int page, String sportName) {
+        Sport sport = sportService.findBySportName(sportName);
+        return gameService.findGamesBySport(page, sport, false);
     }
 
     public Page<Game> getGamesByTeam(int page, long teamId) {
@@ -117,8 +125,18 @@ public class GameFacadeService {
         gameService.deleteGame(game);
     }
 
-    public boolean isSameTeam(long teamId1, long teamId2) {
+    private boolean isSameTeam(long teamId1, long teamId2) {
         return teamId1 == teamId2;
+    }
+
+    private LeagueSeason getLeagueSeason(String sportName) {
+        return switch (sportName) {
+            case "야구" -> LeagueSeason.KBO_2024;
+            case "축구" -> LeagueSeason.K1_2024;
+            case "농구" -> LeagueSeason.KBL_2024_25;
+            case "배구" -> LeagueSeason.V_2024_25;
+            default -> LeagueSeason.UNTITLED;
+        };
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/game/service/GameService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/service/GameService.java
@@ -40,7 +40,8 @@ public class GameService {
     @Transactional(readOnly = true)
     public List<Game> findGamesByTimeOffSale() {
         ZonedDateTime now = ZonedDateTime.now();
-        return gameRepository.findByTimeOffSaleBetween(now.plusMinutes(30), now.plusDays(6));
+        Sort sort = Sort.by(Sort.Direction.ASC, "gameStartTime");
+        return gameRepository.findByTimeOffSaleBetween(now.plusMinutes(30), now.plusDays(6), sort);
     }
 
     public Page<Game> getAllGames(int page) {

--- a/src/main/java/spoticks/ticket_reservation/domain/game/service/GameService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/service/GameService.java
@@ -27,9 +27,7 @@ public class GameService {
 
     @Transactional(readOnly = true)
     public Game findById(Long id) {
-        final Optional<Game> game = gameRepository.findById(id);
-        game.orElseThrow(GameNotFoundException::new);
-        return game.get();
+        return gameRepository.findById(id).orElseThrow(GameNotFoundException::new);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/spoticks/ticket_reservation/domain/game/service/GameService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/service/GameService.java
@@ -24,6 +24,7 @@ public class GameService {
 
     private final GameRepository gameRepository;
     private final int PAGE_SIZE = 8;
+    private final Sort DEFAULT_SORT = Sort.by("gameStartTime").ascending();
 
     @Transactional(readOnly = true)
     public Game findById(Long id) {
@@ -44,25 +45,31 @@ public class GameService {
 
     public Page<Game> getAllGames(int page) {
         return gameRepository.findAll(PageRequest.of(
-                page - 1, PAGE_SIZE, Sort.by("gameStartTime").ascending()));
+                page - 1, PAGE_SIZE, DEFAULT_SORT));
     }
 
     @Transactional(readOnly = true)
     public Page<Game> findGamesBySport(int page, Sport sport, boolean includePastGames) {
         if (includePastGames) {
             return gameRepository.findBySport(sport, PageRequest.of(
-                    page - 1, PAGE_SIZE, Sort.by("gameStartTime").ascending()));
+                    page - 1, PAGE_SIZE, DEFAULT_SORT));
         } else {
             ZonedDateTime now = ZonedDateTime.now();
             return gameRepository.findBySportAndTimeOffSaleAfter(sport, now, PageRequest.of(
-                    page - 1, PAGE_SIZE, Sort.by("gameStartTime").ascending()));
+                    page - 1, PAGE_SIZE, DEFAULT_SORT));
         }
     }
 
     @Transactional(readOnly = true)
-    public Page<Game> findGamesByTeam(int page, Team team) {
-        return gameRepository.findByHomeTeamOrAwayTeamOrderByGameStartTime(
-                team, team, PageRequest.of(page - 1, PAGE_SIZE, Sort.by("gameStartTime").ascending()));
+    public Page<Game> findGamesByTeam(int page, Team team, boolean onlyHomeGames) {
+        ZonedDateTime now = ZonedDateTime.now();
+        if (onlyHomeGames) {
+            return gameRepository.findByHomeTeamAndTimeOffSaleAfter(
+                    team, now, PageRequest.of(page - 1, PAGE_SIZE, DEFAULT_SORT));
+        } else {
+            return gameRepository.findByHomeTeamOrAwayTeamAndTimeOffSaleAfter(
+                    now, team, team, PageRequest.of(page - 1, PAGE_SIZE, DEFAULT_SORT));
+        }
     }
 
     public void saveGame(Game game) {

--- a/src/main/java/spoticks/ticket_reservation/domain/game/service/GameService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/game/service/GameService.java
@@ -48,9 +48,15 @@ public class GameService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Game> findGamesBySport(int page, Sport sport) {
-        return gameRepository.findBySport(sport, PageRequest.of(
-                page - 1, PAGE_SIZE, Sort.by("gameStartTime").ascending()));
+    public Page<Game> findGamesBySport(int page, Sport sport, boolean includePastGames) {
+        if (includePastGames) {
+            return gameRepository.findBySport(sport, PageRequest.of(
+                    page - 1, PAGE_SIZE, Sort.by("gameStartTime").ascending()));
+        } else {
+            ZonedDateTime now = ZonedDateTime.now();
+            return gameRepository.findBySportAndTimeOffSaleAfter(sport, now, PageRequest.of(
+                    page - 1, PAGE_SIZE, Sort.by("gameStartTime").ascending()));
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/spoticks/ticket_reservation/domain/member/contoller/MemberController.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/member/contoller/MemberController.java
@@ -64,19 +64,19 @@ public class MemberController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @PostMapping("/myteam/{teamId}")
+    @PostMapping("/my-team/{teamId}")
     public ResponseEntity addMyTeam(@PathVariable Long teamId) {
         memberFacadeService.addMyTeam(teamId);
         return new ResponseEntity(HttpStatus.OK);
     }
 
-    @DeleteMapping("/myteam/{teamId}")
+    @DeleteMapping("/my-team/{teamId}")
     public ResponseEntity deleteMyTeam(@PathVariable Long teamId) {
         memberFacadeService.deleteMyTeam(teamId);
         return new ResponseEntity(HttpStatus.OK);
     }
 
-    @GetMapping("/myteam")
+    @GetMapping("/my-team")
     public ResponseEntity getMyTeam() {
         List<Team> response = memberFacadeService.getMyTeams();
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/spoticks/ticket_reservation/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/member/exception/MemberNotFoundException.java
@@ -6,7 +6,7 @@ import spoticks.ticket_reservation.global.error.exception.EntityNotFoundExceptio
 public class MemberNotFoundException extends EntityNotFoundException {
 
     public MemberNotFoundException() {
-        super("Member not found", ErrorCode.MEMBER_NOT_FOUND);
+        super(ErrorCode.MEMBER_NOT_FOUND);
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/member/service/MemberFacadeService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/member/service/MemberFacadeService.java
@@ -11,7 +11,7 @@ import spoticks.ticket_reservation.domain.member.exception.PhoneNumberDuplicatio
 import spoticks.ticket_reservation.domain.member.exception.UserNameDuplicationException;
 import spoticks.ticket_reservation.domain.team.entity.Team;
 import spoticks.ticket_reservation.domain.team.service.TeamService;
-import spoticks.ticket_reservation.global.auth.AuthorizationUtil;
+import spoticks.ticket_reservation.global.auth.service.AuthorizationUtil;
 
 import java.util.List;
 

--- a/src/main/java/spoticks/ticket_reservation/domain/member/service/MemberService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/member/service/MemberService.java
@@ -7,8 +7,6 @@ import spoticks.ticket_reservation.domain.member.entity.Member;
 import spoticks.ticket_reservation.domain.member.exception.MemberNotFoundException;
 import spoticks.ticket_reservation.domain.member.repository.MemberRepository;
 
-import java.util.Optional;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -18,16 +16,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public Member findById(Long id) {
-        final Optional<Member> member = memberRepository.findById(id);
-        member.orElseThrow(MemberNotFoundException::new);
-        return member.get();
-    }
-
-    @Transactional(readOnly = true)
-    public Member findByUsername(String username) {
-        final Optional<Member> member = memberRepository.findByUserName(username);
-        member.orElseThrow(MemberNotFoundException::new);
-        return member.get();
+        return memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/spoticks/ticket_reservation/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/reservation/controller/ReservationController.java
@@ -19,7 +19,7 @@ public class ReservationController {
 
     private final ReservationFacadeService reservationFacadeService;
 
-    @GetMapping("/games/{gameId}/preempt")
+    @PostMapping("/games/{gameId}/preempt")
     public ResponseEntity preemptSeat(@PathVariable("gameId") Long gameId, @RequestBody ReservationDto.CheckSeat dto) {
         reservationFacadeService.preemptSeatList(gameId, dto.getSeatIds());
         return new ResponseEntity(HttpStatus.OK);

--- a/src/main/java/spoticks/ticket_reservation/domain/reservation/exception/ReservationNotFoundException.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/reservation/exception/ReservationNotFoundException.java
@@ -6,7 +6,7 @@ import spoticks.ticket_reservation.global.error.exception.EntityNotFoundExceptio
 public class ReservationNotFoundException extends EntityNotFoundException {
 
     public ReservationNotFoundException() {
-        super("Reservation not found", ErrorCode.RESERVATION_NOT_FOUND);
+        super(ErrorCode.RESERVATION_NOT_FOUND);
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/reservation/service/ReservationFacadeService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/reservation/service/ReservationFacadeService.java
@@ -14,10 +14,12 @@ import spoticks.ticket_reservation.domain.reservation.entity.Reservation;
 import spoticks.ticket_reservation.domain.reservation.entity.ReservationStatus;
 import spoticks.ticket_reservation.domain.reservation.exception.CancellationPeriodExpiredException;
 import spoticks.ticket_reservation.domain.seat.entity.Seat;
-import spoticks.ticket_reservation.domain.seat.exception.SeatAlreadySelectedException;
+import spoticks.ticket_reservation.domain.seat.exception.SeatPreemptException;
+import spoticks.ticket_reservation.domain.seat.service.SeatPreemptionService;
 import spoticks.ticket_reservation.domain.seat.service.SeatService;
+import spoticks.ticket_reservation.global.error.ErrorCode;
 import spoticks.ticket_reservation.global.error.exception.AccessDeniedException;
-import spoticks.ticket_reservation.global.auth.AuthorizationUtil;
+import spoticks.ticket_reservation.global.auth.service.AuthorizationUtil;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -30,18 +32,21 @@ public class ReservationFacadeService {
 
     private final ReservationService reservationService;
     private final SeatService seatService;
+    private final SeatPreemptionService preemptionService;
     private final GameService gameService;
     private final MemberService memberService;
 
     public void preemptSeatList(long gameId, List<Long> seatIds) {
         for (long seatId : seatIds) {
             if (!seatService.isSeatAvailable(seatId)) {
-                throw new SeatAlreadySelectedException();
+                throw new SeatPreemptException(ErrorCode.SEAT_ALREADY_SELECTED);
             }
         }
 
+        long memberId = AuthorizationUtil.getMemberId();
+
         for (long seatId : seatIds) {
-            seatService.preemptSeat(seatId);
+            preemptionService.preemptSeat(String.valueOf(seatId), memberId);
         }
     }
 
@@ -52,16 +57,18 @@ public class ReservationFacadeService {
             throw new GameTimeOutOfBoundException();
         }
 
+        long memberId = AuthorizationUtil.getMemberId();
+        final Member member = memberService.findById(memberId);
+
         List<Seat> seatList = new ArrayList<>();
 
         for (long seatId : dto.getSeatIds()) {
+            preemptionService.verifyPreemptionMember(String.valueOf(seatId), memberId);
             Seat seat = seatService.findById(seatId);
             seatService.reserveSeat(seat);
             seatList.add(seat);
         }
 
-        long memberId = AuthorizationUtil.getMemberId();
-        final Member member = memberService.findById(memberId);
         reservationService.saveReservation(dto.toEntity(member, game, seatList));
     }
 

--- a/src/main/java/spoticks/ticket_reservation/domain/reservation/service/ReservationService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/reservation/service/ReservationService.java
@@ -11,8 +11,6 @@ import spoticks.ticket_reservation.domain.reservation.entity.ReservationStatus;
 import spoticks.ticket_reservation.domain.reservation.exception.ReservationNotFoundException;
 import spoticks.ticket_reservation.domain.reservation.repository.ReservationRepository;
 
-import java.util.Optional;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -22,9 +20,7 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public Reservation findReservationById(Long id) {
-        final Optional<Reservation> reservation = reservationRepository.findById(id);
-        reservation.orElseThrow(ReservationNotFoundException::new);
-        return reservation.get();
+        return reservationRepository.findById(id).orElseThrow(ReservationNotFoundException::new);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/entity/Seat.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/entity/Seat.java
@@ -34,9 +34,6 @@ public class Seat {
     private SeatStatus status;
 
     @Column(nullable = false)
-    private int seatPrice;
-
-    @Column(nullable = false)
     private String seatPosition;
 
     @Column(nullable = false)
@@ -58,10 +55,9 @@ public class Seat {
     }
 
     @Builder
-    public Seat(Game game, int seatPrice, String seatPosition, int seatRow, int seatNumber) {
+    public Seat(Game game, String seatPosition, int seatRow, int seatNumber) {
         this.game = game;
         this.status = SeatStatus.AVAILABLE;
-        this.seatPrice = seatPrice;
         this.seatPosition = seatPosition;
         this.seatRow = seatRow;
         this.seatNumber = seatNumber;

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/entity/SeatPreemption.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/entity/SeatPreemption.java
@@ -1,0 +1,29 @@
+package spoticks.ticket_reservation.domain.seat.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@Builder
+@RedisHash("seat")
+public class SeatPreemption {
+
+    @Id
+    private String seatId;
+
+    private Long memberId;
+
+    @TimeToLive
+    private Long expiration;
+
+    public static SeatPreemption from(String seatId, Long memberId, Long expiration) {
+        return SeatPreemption.builder()
+                .seatId(seatId)
+                .memberId(memberId)
+                .expiration(expiration)
+                .build();
+    }
+}

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/exception/SeatNotFoundException.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/exception/SeatNotFoundException.java
@@ -1,11 +1,12 @@
 package spoticks.ticket_reservation.domain.seat.exception;
 
+import spoticks.ticket_reservation.global.error.ErrorCode;
 import spoticks.ticket_reservation.global.error.exception.EntityNotFoundException;
 
 public class SeatNotFoundException extends EntityNotFoundException {
 
     public SeatNotFoundException() {
-        super("Seat not found");
+        super(ErrorCode.SEAT_NOT_FOUND);
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/exception/SeatPreemptException.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/exception/SeatPreemptException.java
@@ -3,10 +3,10 @@ package spoticks.ticket_reservation.domain.seat.exception;
 import spoticks.ticket_reservation.global.error.ErrorCode;
 import spoticks.ticket_reservation.global.error.exception.InvalidValueException;
 
-public class SeatAlreadySelectedException extends InvalidValueException {
+public class SeatPreemptException extends InvalidValueException {
 
-    public SeatAlreadySelectedException() {
-        super("Seat already preempted", ErrorCode.SEAT_ALREADY_SELECTED);
+    public SeatPreemptException(ErrorCode errorCode) {
+        super(errorCode);
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/repository/SeatPreemptionRepository.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/repository/SeatPreemptionRepository.java
@@ -1,0 +1,7 @@
+package spoticks.ticket_reservation.domain.seat.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import spoticks.ticket_reservation.domain.seat.entity.SeatPreemption;
+
+public interface SeatPreemptionRepository extends CrudRepository<SeatPreemption, String> {
+}

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/service/SeatPreemptionService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/service/SeatPreemptionService.java
@@ -1,0 +1,50 @@
+package spoticks.ticket_reservation.domain.seat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import spoticks.ticket_reservation.domain.seat.entity.SeatPreemption;
+import spoticks.ticket_reservation.domain.seat.exception.SeatPreemptException;
+import spoticks.ticket_reservation.domain.seat.repository.SeatPreemptionRepository;
+import spoticks.ticket_reservation.global.error.ErrorCode;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SeatPreemptionService {
+
+    private final SeatPreemptionRepository seatPreemptionRepository;
+
+    private static final long SEAT_PREEMPTION_DURATION = 480L;
+
+    public void preemptSeat(String seatId, long memberId) {
+        Optional<SeatPreemption> existingPreemption = seatPreemptionRepository.findById(seatId);
+
+        if (existingPreemption.isPresent()) {
+            throw new SeatPreemptException(ErrorCode.SEAT_ALREADY_SELECTED);
+        }
+
+        seatPreemptionRepository.save(SeatPreemption.from(
+                seatId, memberId, SEAT_PREEMPTION_DURATION));
+
+    }
+
+    public void verifyPreemptionMember(String seatId, long memberId) {
+        SeatPreemption seatPreemption = seatPreemptionRepository.findById(seatId)
+                .orElseThrow(() -> new SeatPreemptException(ErrorCode.MISMATCHED_SEAT));
+        if (!seatPreemption.getMemberId().equals(memberId)) {
+            throw new SeatPreemptException(ErrorCode.MISMATCHED_SEAT);
+        }
+        cancelPreemption(seatId);
+    }
+
+    public boolean isSeatAvailable(String seatId) {
+        return seatPreemptionRepository.findById(seatId).isEmpty();
+    }
+
+    public void cancelPreemption(String seatId) {
+        seatPreemptionRepository.deleteById(seatId);
+    }
+
+
+}

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/service/SeatService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/service/SeatService.java
@@ -55,12 +55,6 @@ public class SeatService {
         }
     }
 
-    public void preemptSeat(long seatId) {
-        Seat seat = findById(seatId);
-        seat.preempt();
-        seatRepository.save(seat);
-    }
-
     public void reserveSeat(Seat seat) {
         seat.complete();
         seatRepository.save(seat);

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/service/SeatService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/service/SeatService.java
@@ -44,7 +44,6 @@ public class SeatService {
                 for (int c = 1; c <= COL; c++) {
                     Seat seat = Seat.builder()
                             .game(game)
-                            .seatPrice(section.getPrice())
                             .seatPosition(section.getSeatPosition())
                             .seatRow(r)
                             .seatNumber(num++)

--- a/src/main/java/spoticks/ticket_reservation/domain/seat/service/SeatService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/seat/service/SeatService.java
@@ -11,7 +11,6 @@ import spoticks.ticket_reservation.domain.seat.repository.SeatRepository;
 import spoticks.ticket_reservation.domain.stadium.entity.StadiumType;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -22,9 +21,7 @@ public class SeatService {
 
     @Transactional(readOnly = true)
     public Seat findById(Long id) {
-        final Optional<Seat> seat = seatRepository.findById(id);
-        seat.orElseThrow(SeatNotFoundException::new);
-        return seat.get();
+        return seatRepository.findById(id).orElseThrow(SeatNotFoundException::new);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/spoticks/ticket_reservation/domain/sport/service/SportService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/sport/service/SportService.java
@@ -17,15 +17,14 @@ public class SportService {
     private final SportRepository sportRepository;
 
     public Sport findById(Long id) {
-        final Optional<Sport> sport = sportRepository.findById(id);
-        sport.orElseThrow(() -> new EntityNotFoundException("Sport not found"));
-        return sport.get();
+        return sportRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("Sport with id " + id + " not found"));
+
     }
 
     public Sport findBySportName(String sportName) {
-        final Optional<Sport> sport = sportRepository.findBySportName(sportName);
-        sport.orElseThrow(() -> new EntityNotFoundException("Sport not found"));
-        return sport.get();
+        return sportRepository.findBySportName(sportName)
+            .orElseThrow(() -> new EntityNotFoundException("Sport with name " + sportName + " not found"));
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/stadium/service/StadiumService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/stadium/service/StadiumService.java
@@ -7,8 +7,6 @@ import spoticks.ticket_reservation.domain.stadium.entity.Stadium;
 import spoticks.ticket_reservation.domain.stadium.repository.StadiumRepository;
 import spoticks.ticket_reservation.global.error.exception.EntityNotFoundException;
 
-import java.util.Optional;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -17,15 +15,13 @@ public class StadiumService {
     private final StadiumRepository stadiumRepository;
 
     public Stadium findById(Long id) {
-        final Optional<Stadium> stadium = stadiumRepository.findById(id);
-        stadium.orElseThrow(() -> new EntityNotFoundException("Stadium not found"));
-        return stadium.get();
+        return stadiumRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("Stadium with id " + id + " not found"));
     }
 
     public Stadium findByStadiumName(String stadiumName) {
-        final Optional<Stadium> stadium = stadiumRepository.findByStadiumName(stadiumName);
-        stadium.orElseThrow(() -> new EntityNotFoundException("Stadium not found"));
-        return stadium.get();
+        return stadiumRepository.findByStadiumName(stadiumName)
+            .orElseThrow(() -> new EntityNotFoundException("Stadium with name " + stadiumName + " not found"));
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/domain/team/service/TeamService.java
+++ b/src/main/java/spoticks/ticket_reservation/domain/team/service/TeamService.java
@@ -7,8 +7,6 @@ import spoticks.ticket_reservation.domain.team.entity.Team;
 import spoticks.ticket_reservation.domain.team.repository.TeamRepository;
 import spoticks.ticket_reservation.global.error.exception.EntityNotFoundException;
 
-import java.util.Optional;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -17,15 +15,8 @@ public class TeamService {
     private final TeamRepository teamRepository;
 
     public Team findById(Long id) {
-        final Optional<Team> team = teamRepository.findById(id);
-        team.orElseThrow(() -> new EntityNotFoundException("Team not found"));
-        return team.get();
-    }
-
-    public Team findByTeamName(String teamName) {
-        final Optional<Team> team = teamRepository.findByTeamName(teamName);
-        team.orElseThrow(() -> new EntityNotFoundException("Team not found"));
-        return team.get();
+        return teamRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Team with id " + id + " not found"));
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/global/auth/controller/AuthController.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
-package spoticks.ticket_reservation.global.auth;
+package spoticks.ticket_reservation.global.auth.controller;
 
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -8,22 +8,20 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.*;
+import spoticks.ticket_reservation.global.auth.dto.AuthRequest;
+import spoticks.ticket_reservation.global.auth.dto.AuthResponse;
+import spoticks.ticket_reservation.global.auth.entity.CustomUserDetails;
 import spoticks.ticket_reservation.global.auth.service.AuthService;
 import spoticks.ticket_reservation.global.error.ErrorCode;
 import spoticks.ticket_reservation.global.error.ErrorResponse;
 
-
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
     private final AuthenticationManager authenticationManager;
     private final AuthService authService;
-
-    public AuthController(AuthenticationManager authenticationManager, AuthService authService) {
-        this.authenticationManager = authenticationManager;
-        this.authService = authService;
-    }
 
     @PostMapping("/login")
     public ResponseEntity login(@RequestBody AuthRequest authRequest) {

--- a/src/main/java/spoticks/ticket_reservation/global/auth/dto/AuthRequest.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/dto/AuthRequest.java
@@ -1,4 +1,4 @@
-package spoticks.ticket_reservation.global.auth;
+package spoticks.ticket_reservation.global.auth.dto;
 
 import lombok.Getter;
 

--- a/src/main/java/spoticks/ticket_reservation/global/auth/dto/AuthResponse.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/dto/AuthResponse.java
@@ -1,4 +1,4 @@
-package spoticks.ticket_reservation.global.auth;
+package spoticks.ticket_reservation.global.auth.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/spoticks/ticket_reservation/global/auth/entity/CustomUserDetails.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/entity/CustomUserDetails.java
@@ -1,4 +1,4 @@
-package spoticks.ticket_reservation.global.auth;
+package spoticks.ticket_reservation.global.auth.entity;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/spoticks/ticket_reservation/global/auth/entity/LogoutAccessToken.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/entity/LogoutAccessToken.java
@@ -1,7 +1,7 @@
 package spoticks.ticket_reservation.global.auth.entity;
 
-import jakarta.persistence.Id;
 import lombok.Builder;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 

--- a/src/main/java/spoticks/ticket_reservation/global/auth/entity/RefreshToken.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/entity/RefreshToken.java
@@ -1,8 +1,8 @@
 package spoticks.ticket_reservation.global.auth.entity;
 
-import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 

--- a/src/main/java/spoticks/ticket_reservation/global/auth/service/AuthService.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/service/AuthService.java
@@ -3,12 +3,12 @@ package spoticks.ticket_reservation.global.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import spoticks.ticket_reservation.global.auth.AuthResponse;
-import spoticks.ticket_reservation.global.auth.CustomUserDetails;
-import spoticks.ticket_reservation.global.auth.CustomUserDetailsService;
+import spoticks.ticket_reservation.global.auth.dto.AuthResponse;
+import spoticks.ticket_reservation.global.auth.entity.CustomUserDetails;
 import spoticks.ticket_reservation.global.auth.entity.LogoutAccessToken;
 import spoticks.ticket_reservation.global.auth.entity.RefreshToken;
 import spoticks.ticket_reservation.global.auth.exception.TokenCheckFailException;
+import spoticks.ticket_reservation.global.config.JwtConfig;
 import spoticks.ticket_reservation.global.error.ErrorCode;
 import spoticks.ticket_reservation.global.security.JwtTokenizer;
 
@@ -18,14 +18,14 @@ import spoticks.ticket_reservation.global.security.JwtTokenizer;
 public class AuthService {
 
     private final JwtTokenizer jwtTokenizer;
+    private final JwtConfig jwtConfig;
     private final RefreshTokenService refreshTokenService;
     private final LogoutAccessTokenService logoutAccessTokenService;
     private final CustomUserDetailsService userService;
 
-
     public AuthResponse login(CustomUserDetails user) {
-        String accessToken = jwtTokenizer.generateToken(user, JwtTokenizer.ACCESS_TOKEN_EXPIRE);
-        RefreshToken refreshToken = refreshTokenService.saveRefreshToken(user, JwtTokenizer.REFRESH_TOKEN_EXPIRE);
+        String accessToken = jwtTokenizer.generateToken(user, jwtConfig.getAccessTokenExpire());
+        RefreshToken refreshToken = refreshTokenService.saveRefreshToken(user, jwtConfig.getRefreshTokenExpire());
         jwtTokenizer.setRefreshTokenAtCookie(refreshToken);
         return new AuthResponse(accessToken);
     }
@@ -46,7 +46,7 @@ public class AuthService {
         }
 
         String accessToken = jwtTokenizer.generateToken(
-                userService.loadUserByUsername(username), JwtTokenizer.ACCESS_TOKEN_EXPIRE);
+                userService.loadUserByUsername(username), jwtConfig.getAccessTokenExpire());
         return new AuthResponse(accessToken);
     }
 

--- a/src/main/java/spoticks/ticket_reservation/global/auth/service/AuthService.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/service/AuthService.java
@@ -45,9 +45,19 @@ public class AuthService {
             throw new TokenCheckFailException(ErrorCode.MISMATCH_TOKEN);
         }
 
-        String accessToken = jwtTokenizer.generateToken(
-                userService.loadUserByUsername(username), jwtConfig.getAccessTokenExpire());
+        CustomUserDetails user = userService.loadUserByUsername(username);
+
+        if (isRefreshTokenNearExpiry(refreshToken)) {
+            RefreshToken newRefreshToken = refreshTokenService.saveRefreshToken(user, jwtConfig.getRefreshTokenExpire());
+            jwtTokenizer.setRefreshTokenAtCookie(newRefreshToken);
+        }
+
+        String accessToken = jwtTokenizer.generateToken(user, jwtConfig.getAccessTokenExpire());
         return new AuthResponse(accessToken);
+    }
+
+    private boolean isRefreshTokenNearExpiry(String refreshToken) {
+        return jwtTokenizer.getRemainTime(refreshToken) < jwtConfig.getRefreshTokenReissue();
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/global/auth/service/AuthorizationUtil.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/service/AuthorizationUtil.java
@@ -1,8 +1,9 @@
-package spoticks.ticket_reservation.global.auth;
+package spoticks.ticket_reservation.global.auth.service;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import spoticks.ticket_reservation.global.auth.entity.CustomUserDetails;
 
 @Component
 public class AuthorizationUtil {

--- a/src/main/java/spoticks/ticket_reservation/global/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/service/CustomUserDetailsService.java
@@ -1,10 +1,11 @@
-package spoticks.ticket_reservation.global.auth;
+package spoticks.ticket_reservation.global.auth.service;
 
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import spoticks.ticket_reservation.domain.member.entity.Member;
 import spoticks.ticket_reservation.domain.member.repository.MemberRepository;
+import spoticks.ticket_reservation.global.auth.entity.CustomUserDetails;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {

--- a/src/main/java/spoticks/ticket_reservation/global/auth/service/RefreshTokenService.java
+++ b/src/main/java/spoticks/ticket_reservation/global/auth/service/RefreshTokenService.java
@@ -2,7 +2,7 @@ package spoticks.ticket_reservation.global.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import spoticks.ticket_reservation.global.auth.CustomUserDetails;
+import spoticks.ticket_reservation.global.auth.entity.CustomUserDetails;
 import spoticks.ticket_reservation.global.auth.entity.RefreshToken;
 import spoticks.ticket_reservation.global.auth.exception.TokenCheckFailException;
 import spoticks.ticket_reservation.global.auth.repository.RefreshTokenRepository;

--- a/src/main/java/spoticks/ticket_reservation/global/config/JwtConfig.java
+++ b/src/main/java/spoticks/ticket_reservation/global/config/JwtConfig.java
@@ -12,12 +12,19 @@ public class JwtConfig {
     @Value("${jwt.refresh-expire}")
     private String refreshTokenExpireStr;
 
+    @Value("${jwt.refresh-reissue}")
+    private String refreshTokenReissueStr;
+
     public long getAccessTokenExpire() {
         return Long.parseLong(accessTokenExpireStr);
     }
 
     public long getRefreshTokenExpire() {
         return Long.parseLong(refreshTokenExpireStr);
+    }
+
+    public long getRefreshTokenReissue() {
+        return Long.parseLong(refreshTokenReissueStr);
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/global/config/JwtConfig.java
+++ b/src/main/java/spoticks/ticket_reservation/global/config/JwtConfig.java
@@ -1,0 +1,23 @@
+package spoticks.ticket_reservation.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtConfig {
+
+    @Value("${jwt.access-expire}")
+    private String accessTokenExpireStr;
+
+    @Value("${jwt.refresh-expire}")
+    private String refreshTokenExpireStr;
+
+    public long getAccessTokenExpire() {
+        return Long.parseLong(accessTokenExpireStr);
+    }
+
+    public long getRefreshTokenExpire() {
+        return Long.parseLong(refreshTokenExpireStr);
+    }
+
+}

--- a/src/main/java/spoticks/ticket_reservation/global/config/SecurityConfig.java
+++ b/src/main/java/spoticks/ticket_reservation/global/config/SecurityConfig.java
@@ -46,12 +46,12 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login", "/auth/reissue/{username}", "/join", "/join/**",
-                                "/teams/{teamId}/games", "teams/{teamId}/stadium",  "/games/mostPopular", "/games/weekly", "/games/sports").permitAll()
-                        .requestMatchers("/members", "/members/me", "/members/password", "/myteam", "/myteam/{teamId}",
-                                "/reservation", "/reservation/{reservationId}",
-                                "/games/{gameId}/preempt", "/games/{gameId}/reserve", "/games/{gameId}",
-                                "/auth/logout", "/admin/games/**").authenticated()
+                        .requestMatchers("/auth/login", "/auth/reissue/*", "/join", "/join/phone-number", "/join/user-name",
+                                "/teams/*/games", "/teams/*/stadium",  "/games/mostPopular", "/games/weekly", "/games/sports").permitAll()
+                        .requestMatchers("/members", "/members/me", "/members/password", "/my-team", "/my-team/*",
+                                "/reservation", "/reservation/*",
+                                "/games/*/preempt", "/games/*/reserve", "/games/*",
+                                "/auth/logout", "/admin/games", "/admin/games/*").authenticated()
                         .anyRequest().denyAll())
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtEntryPoint))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/spoticks/ticket_reservation/global/config/SecurityConfig.java
+++ b/src/main/java/spoticks/ticket_reservation/global/config/SecurityConfig.java
@@ -12,7 +12,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import spoticks.ticket_reservation.global.auth.CustomUserDetailsService;
+import spoticks.ticket_reservation.global.auth.service.CustomUserDetailsService;
 import spoticks.ticket_reservation.global.security.JwtAuthenticationFilter;
 import spoticks.ticket_reservation.global.security.JwtEntryPoint;
 

--- a/src/main/java/spoticks/ticket_reservation/global/config/WebConfig.java
+++ b/src/main/java/spoticks/ticket_reservation/global/config/WebConfig.java
@@ -10,7 +10,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173", "http://localhost:8080")
+                .allowedOrigins("http://localhost:5173", "https://localhost:5173", "http://localhost:8080",
+                        "https://spoticks.vercel.app", "https://www.spoticks.shop")
                 .allowedMethods("GET", "POST", "PATCH", "DELETE")
                 .allowCredentials(true)
                 .maxAge(3000);

--- a/src/main/java/spoticks/ticket_reservation/global/error/ErrorCode.java
+++ b/src/main/java/spoticks/ticket_reservation/global/error/ErrorCode.java
@@ -40,9 +40,10 @@ public enum ErrorCode {
     RESERVATION_NOT_FOUND(404, "Reservation Not Found"),
 
     // Seat
-    SEAT_ALREADY_SELECTED(400, "Seat already selected"),
+    SEAT_ALREADY_SELECTED(403, "Seat already selected"),
     SEAT_TIMEOUT(400, "Seat occupancy time has ended"),
     SEAT_NOT_FOUND(404, "Seat Not Found"),
+    MISMATCHED_SEAT(403, "Seat does not match"),
     ;
 
     private final int status;

--- a/src/main/java/spoticks/ticket_reservation/global/error/ErrorCode.java
+++ b/src/main/java/spoticks/ticket_reservation/global/error/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     // Seat
     SEAT_ALREADY_SELECTED(400, "Seat already selected"),
     SEAT_TIMEOUT(400, "Seat occupancy time has ended"),
+    SEAT_NOT_FOUND(404, "Seat Not Found"),
     ;
 
     private final int status;

--- a/src/main/java/spoticks/ticket_reservation/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/spoticks/ticket_reservation/global/error/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import spoticks.ticket_reservation.global.error.exception.BusinessException;
 
 import java.nio.file.AccessDeniedException;
@@ -20,7 +21,14 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoHandlerFoundException.class)
     protected ResponseEntity<ErrorResponse> handleNoHandlerFoundException(final NoHandlerFoundException ex) {
-        log.error("handleMethodArgumentNotValidException", ex);
+        log.error("handleNoHandlerFoundException", ex);
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.PAGE_NOT_FOUND);
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNoResourceFoundException(final NoResourceFoundException ex) {
+        log.error("handleNoResourceFoundException", ex);
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.PAGE_NOT_FOUND);
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }

--- a/src/main/java/spoticks/ticket_reservation/global/error/exception/EntityNotFoundException.java
+++ b/src/main/java/spoticks/ticket_reservation/global/error/exception/EntityNotFoundException.java
@@ -12,4 +12,8 @@ public class EntityNotFoundException extends BusinessException {
         super(message, errorCode);
     }
 
+    public EntityNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
 }

--- a/src/main/java/spoticks/ticket_reservation/global/error/exception/InvalidValueException.java
+++ b/src/main/java/spoticks/ticket_reservation/global/error/exception/InvalidValueException.java
@@ -4,8 +4,8 @@ import spoticks.ticket_reservation.global.error.ErrorCode;
 
 public class InvalidValueException extends BusinessException {
 
-    public InvalidValueException(String message) {
-        super(message, ErrorCode.INVALID_INPUT_VALUE);
+    public InvalidValueException(ErrorCode errorCode) {
+        super(errorCode);
     }
 
     public InvalidValueException(String message, ErrorCode errorCode) {

--- a/src/main/java/spoticks/ticket_reservation/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/spoticks/ticket_reservation/global/security/JwtAuthenticationFilter.java
@@ -29,10 +29,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        if (isPermitAllPath(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         try {
             String jwt = getJwtFromRequest(request);
 
-            if (jwt != null && jwtTokenizer.verifyToken(jwt)) {
+            if (jwtTokenizer.verifyToken(jwt)) {
                 String username = jwtTokenizer.parseClaims(jwt).getSubject();
                 CustomUserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
@@ -70,6 +75,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    private boolean isPermitAllPath(String requestURI) {
+        return requestURI.startsWith("/auth/login") ||
+                requestURI.startsWith("/auth/reissue") ||
+                requestURI.startsWith("/join") ||
+                requestURI.startsWith("/games/mostPopular") ||
+                requestURI.startsWith("/games/weekly") ||
+                requestURI.startsWith("/games/sports") ||
+                requestURI.startsWith("/teams");
     }
 
 }

--- a/src/main/java/spoticks/ticket_reservation/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/spoticks/ticket_reservation/global/security/JwtAuthenticationFilter.java
@@ -11,8 +11,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import spoticks.ticket_reservation.global.auth.CustomUserDetails;
-import spoticks.ticket_reservation.global.auth.CustomUserDetailsService;
+import spoticks.ticket_reservation.global.auth.entity.CustomUserDetails;
+import spoticks.ticket_reservation.global.auth.service.CustomUserDetailsService;
 import spoticks.ticket_reservation.global.error.exception.AccessDeniedException;
 import spoticks.ticket_reservation.global.error.exception.JwtAuthenticationException;
 

--- a/src/main/java/spoticks/ticket_reservation/global/security/JwtEntryPoint.java
+++ b/src/main/java/spoticks/ticket_reservation/global/security/JwtEntryPoint.java
@@ -21,13 +21,13 @@ public class JwtEntryPoint implements AuthenticationEntryPoint {
                          AuthenticationException authException) throws IOException {
         ErrorCode errorCode = (ErrorCode) request.getAttribute("errorCode");
 
-        if (errorCode == null) {
-            errorCode = ErrorCode.PAGE_NOT_FOUND;
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-        } else if (errorCode == ErrorCode.HANDLE_ACCESS_DENIED) {
+        if (errorCode == ErrorCode.HANDLE_ACCESS_DENIED) {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         } else {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            if (errorCode == null) {
+                errorCode = ErrorCode.PAGE_NOT_FOUND;
+            }
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
         }
 
         ErrorResponse errorResponse = ErrorResponse.of(errorCode);

--- a/src/main/java/spoticks/ticket_reservation/global/security/JwtTokenizer.java
+++ b/src/main/java/spoticks/ticket_reservation/global/security/JwtTokenizer.java
@@ -49,6 +49,10 @@ public class JwtTokenizer {
     }
 
     public boolean verifyToken(String authToken) {
+        if (authToken == null) {
+            throwJwtException(ErrorCode.EMPTY_TOKEN);
+        }
+
         try {
             validateToken(authToken);
 

--- a/src/main/java/spoticks/ticket_reservation/global/security/JwtTokenizer.java
+++ b/src/main/java/spoticks/ticket_reservation/global/security/JwtTokenizer.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-import spoticks.ticket_reservation.global.auth.CustomUserDetails;
+import spoticks.ticket_reservation.global.auth.entity.CustomUserDetails;
 import spoticks.ticket_reservation.global.auth.entity.RefreshToken;
 import spoticks.ticket_reservation.global.auth.service.LogoutAccessTokenService;
 import spoticks.ticket_reservation.global.error.ErrorCode;
@@ -22,9 +22,6 @@ public class JwtTokenizer {
 
     @Value("${jwt.secret}")
     private String JWT_SECRET;
-
-    public static final long ACCESS_TOKEN_EXPIRE = 1000L * 60 * 2; // 5분
-    public static final long REFRESH_TOKEN_EXPIRE = 1000L * 60 * 3; // 7분
 
     private final LogoutAccessTokenService logoutAccessTokenService;
 
@@ -83,9 +80,9 @@ public class JwtTokenizer {
     public void setRefreshTokenAtCookie(RefreshToken refreshToken) {
         Cookie cookie = new Cookie("RefreshToken", refreshToken.getRefreshToken());
         cookie.setHttpOnly(true);
-        // cookie.setSecure(true); HTTPS 적용
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
         cookie.setMaxAge(refreshToken.getExpiration().intValue());
-        cookie.setAttribute("SameSite", "Strict");
         HttpServletResponse response = ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder
                 .getRequestAttributes())).getResponse();
         Objects.requireNonNull(response).addCookie(cookie);

--- a/src/main/java/spoticks/ticket_reservation/global/security/JwtTokenizer.java
+++ b/src/main/java/spoticks/ticket_reservation/global/security/JwtTokenizer.java
@@ -81,6 +81,7 @@ public class JwtTokenizer {
         Cookie cookie = new Cookie("RefreshToken", refreshToken.getRefreshToken());
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
+        cookie.setPath("/");
         cookie.setAttribute("SameSite", "None");
         cookie.setMaxAge(refreshToken.getExpiration().intValue());
         HttpServletResponse response = ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,5 @@ logging:
     org.hibernate.SQL: debug
 jwt:
   secret: ${JWT_SECRET_KEY}
+  access-expire: ${ACCESS_EXPIRE}
+  refresh-expire: ${REFRESH_EXPIRE}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,4 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-expire: ${ACCESS_EXPIRE}
   refresh-expire: ${REFRESH_EXPIRE}
+  refresh-reissue: ${REFRESH_REISSUE}


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #25 #26 #27 #28 #29 #30 #31 #32 #33 #34 #35

<br>

## 무엇이 추가 되었나요?

- 액세스 토큰을 재발급할 때, 리프레시 토큰이 만료기간이 일정 시간 미만으로 남아있을 경우 리프레시 토큰도 재발급
- 어드민 종목 조회는 과거 경기 포함, 유저가 보는 경기목록(팀별, 종목별)은 과거 경기 제외
- 팀별 경기 목록의 '홈 경기만 보기' 옵션 추가
- Seat 엔티티의 컬럼 중 'seatPrice' 삭제
- requestMatcher 를 spring security ant 패턴에 맞게 수정
- 인증에 실패한 경우와 올바른 엔드포인트가 아닌 경우의 에러 처리 분기
- 주간 경기 목록을 경기 시작 시간 오름차순으로 정렬

<br>

